### PR TITLE
紧急处理：调用的  https://ipcheck.need.sh 检测服务因为面板太多人更新，请求量变大，导致对方扛不住了，然后面板报各…

### DIFF
--- a/app/Console/Commands/AutoJob.php
+++ b/app/Console/Commands/AutoJob.php
@@ -328,6 +328,7 @@ class AutoJob extends Command
     // TCP检测
     private function tcpCheck($ip)
     {
+        return 0;
         try {
             $tcpCN = $this->curlRequest("https://ipcheck.need.sh/api.php?location=cn&ip={$ip}&type=tcp");
             $tcpUS = $this->curlRequest("https://ipcheck.need.sh/api.php?location=us&ip={$ip}&type=tcp");


### PR DESCRIPTION
…种TCP阻断、海外不通，所以禁用防墙监测